### PR TITLE
fix tailrec version of recursion

### DIFF
--- a/src/main/scala/com/creditkarma/talks/examples/RecursionBenchmark.scala
+++ b/src/main/scala/com/creditkarma/talks/examples/RecursionBenchmark.scala
@@ -148,30 +148,44 @@ class RecursionBenchmark {
   }
 
   @Benchmark
-  def calculateByTailRecursionBenchInt(): Int =
-    calculateByTailRecursion[Int](start)
-
-  @Benchmark
-  def calculateByTailRecursionBenchLong(): Long =
-    calculateByTailRecursion[Long](start)
-
-  @Benchmark
-  def calculateByTailRecursionBenchBigInt(): BigInt =
-    calculateByTailRecursion[BigInt](start)
-
-  @Benchmark
-  def calculateByTailRecursionBenchDouble(): Double =
-    calculateByTailRecursion[Double](start)
-
-  def calculateByTailRecursion[T](n: T)(implicit x: Numeric[T]): T = {
-    import x._
-
-    @tailrec def fac(n: T, acc: T): T = {
-      if (one == n) acc
-      else fac(n - one, n * acc)
+  def calculateByTailRecursionBenchInt(): Int = {
+    @tailrec def fac(res: Int, i: Int): Int = {
+      if (i <= start) fac(res * i, i + 1)
+      else res
     }
 
-    fac(n, one)
+    fac(1, 2)
+  }
+
+  @Benchmark
+  def calculateByTailRecursionBenchLong(): Long = {
+    val startL = start.toLong
+    @tailrec def fac(res: Long, i: Long): Long = {
+      if (i <= startL) fac(res * i, i + 1l)
+      else res
+    }
+
+    fac(1l, 2l)
+  }
+
+  @Benchmark
+  def calculateByTailRecursionBenchBigInt(): BigInt = {
+    @tailrec def fac(res: BigInt, i: Int): BigInt = {
+      if (i <= start) fac(res * BigInt(i), i + 1)
+      else res
+    }
+
+    fac(BigInt(1), 2)
+  }
+
+  @Benchmark
+  def calculateByTailRecursionBenchDouble(): Double = {
+    @tailrec def fac(res: Double, i: Int): Double = {
+      if (i <= start) fac(res * i.toDouble, i + 1)
+      else res
+    }
+
+    fac(1.0D, 2)
   }
 
   @Benchmark


### PR DESCRIPTION
Tail Recursion should be as faster as a while-loop, sometimes even faster because of internal compiler optimizations. If it's not the case then the developer has done something wrong. In the case of your code, the tail recursion version of `fac` the "slowness" of the implementation is caused by how you implemented `fac`, which is different from the while example, and has nothing to do with tail recursion. I've attached to this email a screenshot of the score of my tail recursion implementation (ending with 2) to show that tail recursion is on pair with the while loop. I have only tested `Long` because I don't have time for the other three tests but I'm fairly confident the result will be similar.

![tailrecawesome](https://user-images.githubusercontent.com/1481478/28520238-fbc91698-706e-11e7-9450-41add1e4e2c8.PNG)
